### PR TITLE
Make compatible with @apollo/gateway >= 0.10.8

### DIFF
--- a/node-gateway.js
+++ b/node-gateway.js
@@ -115,15 +115,20 @@ class NodeGateway extends ApolloGateway {
   }
 
   /**
-   * Override `createDataSource` to support local Node resolution service.
+   * Override `createAndCacheDataSource` to support local Node resolution service.
    */
-  createDataSource(serviceDef) {
+  createAndCacheDataSource(serviceDef) {
     // Special case for the local Node resolution service
     if (serviceDef.schema) {
-      return new LocalGraphQLDataSource(serviceDef.schema);
+      const dataSource = new LocalGraphQLDataSource(serviceDef.schema);
+
+      // Cache the created DataSource
+      this.serviceMap[serviceDef.name] = dataSource;
+
+      return dataSource
     }
 
-    return super.createDataSource(serviceDef);
+    return super.createAndCacheDataSource(serviceDef);
   }
 }
 

--- a/node-gateway.js
+++ b/node-gateway.js
@@ -123,7 +123,7 @@ class NodeGateway extends ApolloGateway {
       const dataSource = new LocalGraphQLDataSource(serviceDef.schema);
 
       // Cache the created DataSource
-      this.serviceMap[serviceDef.name] = dataSource;
+      this.serviceMap[serviceDef.name] = { dataSource };
 
       return dataSource
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,41 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@apollo/federation": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.9.4.tgz",
-      "integrity": "sha512-s5vQ+yAJn+ULpWoiTS62iwa5VaI5wQ2zFSHUrhS1xurpKbkZA0gZ1P2XGJowAHKOd+mwLByKnwRxqkn0bQOGJQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.13.2.tgz",
+      "integrity": "sha512-62uXIIHxHXG71gSwROFt8yxtYeUZ2BaIgAkxZ1H82GB4+s1gt4xwizcmmCWqQhK3KBy4LbPOfI1YyHW4Wv5ZpQ==",
       "requires": {
-        "apollo-env": "^0.5.1",
-        "apollo-graphql": "^0.3.3",
+        "apollo-graphql": "^0.4.0",
         "apollo-server-env": "^2.4.3",
+        "core-js": "^3.4.0",
         "lodash.xorby": "^4.7.0"
+      },
+      "dependencies": {
+        "apollo-env": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
+          "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
+          "requires": {
+            "@types/node-fetch": "2.5.5",
+            "core-js": "^3.0.1",
+            "node-fetch": "^2.2.0",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "apollo-graphql": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
+          "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
+          "requires": {
+            "apollo-env": "^0.6.2",
+            "lodash.sortby": "^4.7.0"
+          }
+        },
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+        }
       }
     },
     "@apollo/gateway": {
@@ -31,6 +58,39 @@
         "loglevel": "^1.6.1",
         "loglevel-debug": "^0.0.1",
         "pretty-format": "^24.7.0"
+      },
+      "dependencies": {
+        "@apollo/federation": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.9.4.tgz",
+          "integrity": "sha512-s5vQ+yAJn+ULpWoiTS62iwa5VaI5wQ2zFSHUrhS1xurpKbkZA0gZ1P2XGJowAHKOd+mwLByKnwRxqkn0bQOGJQ==",
+          "requires": {
+            "apollo-env": "^0.5.1",
+            "apollo-graphql": "^0.3.3",
+            "apollo-server-env": "^2.4.3",
+            "lodash.xorby": "^4.7.0"
+          }
+        }
+      }
+    },
+    "@apollo/protobufjs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.3.tgz",
+      "integrity": "sha512-gqeT810Ect9WIqsrgfUvr+ljSB5m1PyBae9HGdrRyQ3HjHjTcjVvxpsMYXlUk4rUHnrfUqyoGvLSy2yLlRGEOw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
       }
     },
     "@apollographql/apollo-tools": {
@@ -260,6 +320,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
       "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -396,69 +465,114 @@
       }
     },
     "apollo-server": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.9.3.tgz",
-      "integrity": "sha512-JQoeseSo3yOBu3WJzju0NTreoqYckNILybgXNUOhdurE55VFpZ8dsBEO6nMfdO2y1A70W14mnnVWCBEm+1rE8w==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.11.0.tgz",
+      "integrity": "sha512-UhW6RHPBMWZy1v7KhzssUnxPBxpu9fGFajtqP68vtvvP3+xa2Y2GUg0594bHcUcLK+BjdMBQQSW27i0yQ/Fz9g==",
       "requires": {
-        "apollo-server-core": "^2.9.3",
-        "apollo-server-express": "^2.9.3",
+        "apollo-server-core": "^2.11.0",
+        "apollo-server-express": "^2.11.0",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
       },
       "dependencies": {
+        "@apollographql/apollo-tools": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
+          "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
+          "requires": {
+            "apollo-env": "^0.6.2"
+          }
+        },
         "apollo-cache-control": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.4.tgz",
-          "integrity": "sha512-IZ1d3AXZtkZhLYo0kWqTbZ6nqLFaeUvLdMESs+9orMadBZ7mvzcAfBwrhKyCWPGeAAZ/jKv8FtYHybpchHgFAg==",
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
+          "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
           "requires": {
             "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.10.3"
+            "graphql-extensions": "^0.11.0"
           }
         },
         "apollo-datasource": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.3.tgz",
-          "integrity": "sha512-gRYyFVpJgHE2hhS+VxMeOerxXQ/QYxWG7T6QddfugJWYAG9DRCl65e2b7txcGq2NP3r+O1iCm4GNwhRBDJbd8A==",
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
+          "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
           "requires": {
-            "apollo-server-caching": "^0.5.0",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3"
           }
         },
         "apollo-engine-reporting": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.6.tgz",
-          "integrity": "sha512-acfb7oFnru/8YQdY4x6+7WJbZfzdVETI8Cl+9ImgUrvUnE8P+f2SsGTKXTC1RuUvve4c56PAvaPgE+z8X1a1Mw==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
+          "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
           "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.0",
-            "apollo-graphql": "^0.3.3",
-            "apollo-server-caching": "^0.5.0",
+            "apollo-engine-reporting-protobuf": "^0.4.4",
+            "apollo-graphql": "^0.4.0",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3",
-            "apollo-server-types": "^0.2.4",
+            "apollo-server-errors": "^2.4.0",
+            "apollo-server-types": "^0.3.0",
             "async-retry": "^1.2.1",
-            "graphql-extensions": "^0.10.3"
+            "graphql-extensions": "^0.11.0"
+          }
+        },
+        "apollo-engine-reporting-protobuf": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
+          "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
+          "requires": {
+            "@apollo/protobufjs": "^1.0.3"
+          }
+        },
+        "apollo-env": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
+          "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
+          "requires": {
+            "@types/node-fetch": "2.5.5",
+            "core-js": "^3.0.1",
+            "node-fetch": "^2.2.0",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "apollo-graphql": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
+          "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
+          "requires": {
+            "apollo-env": "^0.6.2",
+            "lodash.sortby": "^4.7.0"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
+          "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
+          "requires": {
+            "lru-cache": "^5.0.0"
           }
         },
         "apollo-server-core": {
-          "version": "2.9.3",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.3.tgz",
-          "integrity": "sha512-KQpOM3nAXdMqKVE0HHcOkH/EVhyDqFEKLNFlsyGHGOn9ujpI6RsltX+YpXRyAdbfQHpTk11v/IAo6XksWN+g1Q==",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
+          "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
           "requires": {
-            "@apollographql/apollo-tools": "^0.4.0",
+            "@apollographql/apollo-tools": "^0.4.3",
             "@apollographql/graphql-playground-html": "1.6.24",
             "@types/graphql-upload": "^8.0.0",
             "@types/ws": "^6.0.0",
-            "apollo-cache-control": "^0.8.4",
-            "apollo-datasource": "^0.6.3",
-            "apollo-engine-reporting": "^1.4.6",
-            "apollo-server-caching": "^0.5.0",
+            "apollo-cache-control": "^0.9.0",
+            "apollo-datasource": "^0.7.0",
+            "apollo-engine-reporting": "^1.7.0",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3",
-            "apollo-server-errors": "^2.3.3",
-            "apollo-server-plugin-base": "^0.6.4",
-            "apollo-server-types": "^0.2.4",
-            "apollo-tracing": "^0.8.4",
+            "apollo-server-errors": "^2.4.0",
+            "apollo-server-plugin-base": "^0.7.0",
+            "apollo-server-types": "^0.3.0",
+            "apollo-tracing": "^0.9.0",
             "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.10.3",
+            "graphql-extensions": "^0.11.0",
             "graphql-tag": "^2.9.2",
             "graphql-tools": "^4.0.0",
             "graphql-upload": "^8.0.2",
@@ -467,55 +581,46 @@
             "ws": "^6.0.0"
           }
         },
-        "apollo-server-env": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.3.tgz",
-          "integrity": "sha512-23R5Xo9OMYX0iyTu2/qT0EUb+AULCBriA9w8HDfMoChB8M+lFClqUkYtaTTHDfp6eoARLW8kDBhPOBavsvKAjA==",
-          "requires": {
-            "node-fetch": "^2.1.2",
-            "util.promisify": "^1.0.0"
-          }
-        },
         "apollo-server-errors": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.3.tgz",
-          "integrity": "sha512-MO4oJ129vuCcbqwr5ZwgxqGGiLz3hCyowz0bstUF7MR+vNGe4oe3DWajC9lv4CxrhcqUHQOeOPViOdIo1IxE3g=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
+          "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
         },
         "apollo-server-plugin-base": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.4.tgz",
-          "integrity": "sha512-4rY+cBAIpQomGWYBtk8hHkLQWHrh5hgIBPQqmhXh00YFdcY+Ob1/cU2/2iqTcIzhtcaezsc8OZ63au6ahSBQqg==",
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
+          "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
           "requires": {
-            "apollo-server-types": "^0.2.4"
+            "apollo-server-types": "^0.3.0"
           }
         },
         "apollo-server-types": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.4.tgz",
-          "integrity": "sha512-G4FvBVgGQcTW6ZBS2+hvcDQkSfdOIKV+cHADduXA275v+5zl42g+bCaGd/hCCKTDRjmQvObLiMxH/BJ6pDMQgA==",
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
+          "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
           "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.0",
-            "apollo-server-caching": "^0.5.0",
+            "apollo-engine-reporting-protobuf": "^0.4.4",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3"
           }
         },
         "apollo-tracing": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.4.tgz",
-          "integrity": "sha512-DjbFW0IvHicSlTVG+vK+1WINfBMRCdPPHJSW/j65JMir9Oe56WGeqL8qz8hptdUUmLYEb+azvcyyGsJsiR3zpQ==",
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
+          "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
           "requires": {
             "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.10.3"
+            "graphql-extensions": "^0.11.0"
           }
         },
         "graphql-extensions": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.3.tgz",
-          "integrity": "sha512-kwU0gUe+Qdfr8iZYT91qrPSwQNgPhB/ClF1m1LEPdxlptk5FhFmjpxAcbMZ8q7j0kjfnbp2IeV1OhRDCEPqz2w==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
+          "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
           "requires": {
-            "@apollographql/apollo-tools": "^0.4.0",
+            "@apollographql/apollo-tools": "^0.4.3",
             "apollo-server-env": "^2.4.3",
-            "apollo-server-types": "^0.2.4"
+            "apollo-server-types": "^0.3.0"
           }
         }
       }
@@ -571,18 +676,18 @@
       "integrity": "sha512-MO4oJ129vuCcbqwr5ZwgxqGGiLz3hCyowz0bstUF7MR+vNGe4oe3DWajC9lv4CxrhcqUHQOeOPViOdIo1IxE3g=="
     },
     "apollo-server-express": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.3.tgz",
-      "integrity": "sha512-Hkfs+ce6GqaoSzDOJs8Pj7W3YUjH0BzGglo5HMsOXOnjPZ0pJE9v8fmK76rlkITLw7GjvIq5GKlafymC31FMBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.11.0.tgz",
+      "integrity": "sha512-9bbiD+zFAx+xyurc9lxYmNa9y79k/gsA1vEyPFVcv7jxzCFC5wc0tcbV7NPX2qi1Nn7K76fxo2fPNYbPFX/y0g==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
-        "@types/body-parser": "1.17.1",
+        "@types/body-parser": "1.19.0",
         "@types/cors": "^2.8.4",
-        "@types/express": "4.17.1",
+        "@types/express": "4.17.2",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.9.3",
-        "apollo-server-types": "^0.2.4",
+        "apollo-server-core": "^2.11.0",
+        "apollo-server-types": "^0.3.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
@@ -593,58 +698,122 @@
         "type-is": "^1.6.16"
       },
       "dependencies": {
+        "@apollographql/apollo-tools": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
+          "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
+          "requires": {
+            "apollo-env": "^0.6.2"
+          }
+        },
+        "@types/body-parser": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+          "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "@types/express": {
+          "version": "4.17.2",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
+          "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "*",
+            "@types/serve-static": "*"
+          }
+        },
         "apollo-cache-control": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.4.tgz",
-          "integrity": "sha512-IZ1d3AXZtkZhLYo0kWqTbZ6nqLFaeUvLdMESs+9orMadBZ7mvzcAfBwrhKyCWPGeAAZ/jKv8FtYHybpchHgFAg==",
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
+          "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
           "requires": {
             "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.10.3"
+            "graphql-extensions": "^0.11.0"
           }
         },
         "apollo-datasource": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.3.tgz",
-          "integrity": "sha512-gRYyFVpJgHE2hhS+VxMeOerxXQ/QYxWG7T6QddfugJWYAG9DRCl65e2b7txcGq2NP3r+O1iCm4GNwhRBDJbd8A==",
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
+          "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
           "requires": {
-            "apollo-server-caching": "^0.5.0",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3"
           }
         },
         "apollo-engine-reporting": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.6.tgz",
-          "integrity": "sha512-acfb7oFnru/8YQdY4x6+7WJbZfzdVETI8Cl+9ImgUrvUnE8P+f2SsGTKXTC1RuUvve4c56PAvaPgE+z8X1a1Mw==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
+          "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
           "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.0",
-            "apollo-graphql": "^0.3.3",
-            "apollo-server-caching": "^0.5.0",
+            "apollo-engine-reporting-protobuf": "^0.4.4",
+            "apollo-graphql": "^0.4.0",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3",
-            "apollo-server-types": "^0.2.4",
+            "apollo-server-errors": "^2.4.0",
+            "apollo-server-types": "^0.3.0",
             "async-retry": "^1.2.1",
-            "graphql-extensions": "^0.10.3"
+            "graphql-extensions": "^0.11.0"
+          }
+        },
+        "apollo-engine-reporting-protobuf": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
+          "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
+          "requires": {
+            "@apollo/protobufjs": "^1.0.3"
+          }
+        },
+        "apollo-env": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
+          "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
+          "requires": {
+            "@types/node-fetch": "2.5.5",
+            "core-js": "^3.0.1",
+            "node-fetch": "^2.2.0",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "apollo-graphql": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
+          "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
+          "requires": {
+            "apollo-env": "^0.6.2",
+            "lodash.sortby": "^4.7.0"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
+          "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
+          "requires": {
+            "lru-cache": "^5.0.0"
           }
         },
         "apollo-server-core": {
-          "version": "2.9.3",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.3.tgz",
-          "integrity": "sha512-KQpOM3nAXdMqKVE0HHcOkH/EVhyDqFEKLNFlsyGHGOn9ujpI6RsltX+YpXRyAdbfQHpTk11v/IAo6XksWN+g1Q==",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
+          "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
           "requires": {
-            "@apollographql/apollo-tools": "^0.4.0",
+            "@apollographql/apollo-tools": "^0.4.3",
             "@apollographql/graphql-playground-html": "1.6.24",
             "@types/graphql-upload": "^8.0.0",
             "@types/ws": "^6.0.0",
-            "apollo-cache-control": "^0.8.4",
-            "apollo-datasource": "^0.6.3",
-            "apollo-engine-reporting": "^1.4.6",
-            "apollo-server-caching": "^0.5.0",
+            "apollo-cache-control": "^0.9.0",
+            "apollo-datasource": "^0.7.0",
+            "apollo-engine-reporting": "^1.7.0",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3",
-            "apollo-server-errors": "^2.3.3",
-            "apollo-server-plugin-base": "^0.6.4",
-            "apollo-server-types": "^0.2.4",
-            "apollo-tracing": "^0.8.4",
+            "apollo-server-errors": "^2.4.0",
+            "apollo-server-plugin-base": "^0.7.0",
+            "apollo-server-types": "^0.3.0",
+            "apollo-tracing": "^0.9.0",
             "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.10.3",
+            "graphql-extensions": "^0.11.0",
             "graphql-tag": "^2.9.2",
             "graphql-tools": "^4.0.0",
             "graphql-upload": "^8.0.2",
@@ -653,55 +822,46 @@
             "ws": "^6.0.0"
           }
         },
-        "apollo-server-env": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.3.tgz",
-          "integrity": "sha512-23R5Xo9OMYX0iyTu2/qT0EUb+AULCBriA9w8HDfMoChB8M+lFClqUkYtaTTHDfp6eoARLW8kDBhPOBavsvKAjA==",
-          "requires": {
-            "node-fetch": "^2.1.2",
-            "util.promisify": "^1.0.0"
-          }
-        },
         "apollo-server-errors": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.3.tgz",
-          "integrity": "sha512-MO4oJ129vuCcbqwr5ZwgxqGGiLz3hCyowz0bstUF7MR+vNGe4oe3DWajC9lv4CxrhcqUHQOeOPViOdIo1IxE3g=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
+          "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
         },
         "apollo-server-plugin-base": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.4.tgz",
-          "integrity": "sha512-4rY+cBAIpQomGWYBtk8hHkLQWHrh5hgIBPQqmhXh00YFdcY+Ob1/cU2/2iqTcIzhtcaezsc8OZ63au6ahSBQqg==",
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
+          "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
           "requires": {
-            "apollo-server-types": "^0.2.4"
+            "apollo-server-types": "^0.3.0"
           }
         },
         "apollo-server-types": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.4.tgz",
-          "integrity": "sha512-G4FvBVgGQcTW6ZBS2+hvcDQkSfdOIKV+cHADduXA275v+5zl42g+bCaGd/hCCKTDRjmQvObLiMxH/BJ6pDMQgA==",
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
+          "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
           "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.0",
-            "apollo-server-caching": "^0.5.0",
+            "apollo-engine-reporting-protobuf": "^0.4.4",
+            "apollo-server-caching": "^0.5.1",
             "apollo-server-env": "^2.4.3"
           }
         },
         "apollo-tracing": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.4.tgz",
-          "integrity": "sha512-DjbFW0IvHicSlTVG+vK+1WINfBMRCdPPHJSW/j65JMir9Oe56WGeqL8qz8hptdUUmLYEb+azvcyyGsJsiR3zpQ==",
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
+          "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
           "requires": {
             "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.10.3"
+            "graphql-extensions": "^0.11.0"
           }
         },
         "graphql-extensions": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.3.tgz",
-          "integrity": "sha512-kwU0gUe+Qdfr8iZYT91qrPSwQNgPhB/ClF1m1LEPdxlptk5FhFmjpxAcbMZ8q7j0kjfnbp2IeV1OhRDCEPqz2w==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
+          "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
           "requires": {
-            "@apollographql/apollo-tools": "^0.4.0",
+            "@apollographql/apollo-tools": "^0.4.3",
             "apollo-server-env": "^2.4.3",
-            "apollo-server-types": "^0.2.4"
+            "apollo-server-types": "^0.3.0"
           }
         }
       }
@@ -761,6 +921,11 @@
       "requires": {
         "retry": "0.12.0"
       }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "backo2": {
       "version": "1.0.2",
@@ -829,6 +994,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -888,6 +1061,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -1023,6 +1201,16 @@
         "unpipe": "~1.0.0"
       }
     },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1044,9 +1232,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "graphql": {
-      "version": "14.5.6",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.6.tgz",
-      "integrity": "sha512-zJ6Oz8P1yptV4O4DYXdArSwvmirPetDOBnGFRBl0zQEC68vNW3Ny8qo8VzMgfr+iC8PKiRYJ+f2wub41oDCoQg==",
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
       "requires": {
         "iterall": "^1.2.2"
       }
@@ -1144,9 +1332,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ipaddr.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -1236,16 +1424,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.43.0"
       }
     },
     "ms": {
@@ -1342,12 +1530,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.0"
+        "ipaddr.js": "1.9.1"
       }
     },
     "qs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,33 +42,32 @@
       }
     },
     "@apollo/gateway": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.10.4.tgz",
-      "integrity": "sha512-ydwfDQnDzQVxLK8XyPU5pQ+HsGeVQlMFz2p4iPCyQizQTty0SXCXqgC6bPFqfZ7+/MvRKxeTMM+J6/Umz9PDmg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.13.2.tgz",
+      "integrity": "sha512-1f5qCzplvE4sGFhK/ir2YUuFLTRO8ujEcSbsFFsHA+n4E8e8S92V+9X32MRXzu3gZYkfqdhnrd/bJFtTVtlkWA==",
       "requires": {
-        "@apollo/federation": "^0.9.4",
-        "apollo-engine-reporting-protobuf": "^0.4.0",
-        "apollo-env": "^0.5.1",
-        "apollo-graphql": "^0.3.3",
-        "apollo-server-caching": "^0.5.0",
-        "apollo-server-core": "^2.9.3",
+        "@apollo/federation": "^0.13.2",
+        "@types/node-fetch": "2.5.4",
+        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-env": "^0.6.1",
+        "apollo-graphql": "^0.4.0",
+        "apollo-server-caching": "^0.5.1",
+        "apollo-server-core": "^2.11.0",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.2.4",
-        "graphql-extensions": "^0.10.3",
+        "apollo-server-types": "^0.3.0",
+        "graphql-extensions": "^0.11.0",
         "loglevel": "^1.6.1",
         "loglevel-debug": "^0.0.1",
+        "make-fetch-happen": "^7.1.1",
         "pretty-format": "^24.7.0"
       },
       "dependencies": {
-        "@apollo/federation": {
-          "version": "0.9.4",
-          "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.9.4.tgz",
-          "integrity": "sha512-s5vQ+yAJn+ULpWoiTS62iwa5VaI5wQ2zFSHUrhS1xurpKbkZA0gZ1P2XGJowAHKOd+mwLByKnwRxqkn0bQOGJQ==",
+        "@types/node-fetch": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+          "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
           "requires": {
-            "apollo-env": "^0.5.1",
-            "apollo-graphql": "^0.3.3",
-            "apollo-server-env": "^2.4.3",
-            "lodash.xorby": "^4.7.0"
+            "@types/node": "*"
           }
         }
       }
@@ -94,11 +93,11 @@
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz",
-      "integrity": "sha512-7wEO+S+zgz/wVe3ilFQqICufRBYYDSNUkd1V03JWvXuSydbYq2SM5EgvWmFF+04iadt+aQ0XCCsRzCzRPQODfQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
+      "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
       "requires": {
-        "apollo-env": "0.5.1"
+        "apollo-env": "^0.6.2"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -263,9 +262,9 @@
       "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
     },
     "@types/istanbul-lib-report": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -352,17 +351,17 @@
       }
     },
     "@types/yargs": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
-      "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@wry/equality": {
       "version": "0.1.9",
@@ -381,6 +380,45 @@
         "negotiator": "0.6.2"
       }
     },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+    },
+    "agentkeepalive": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.0.tgz",
+      "integrity": "sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -395,61 +433,63 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.4.tgz",
-      "integrity": "sha512-IZ1d3AXZtkZhLYo0kWqTbZ6nqLFaeUvLdMESs+9orMadBZ7mvzcAfBwrhKyCWPGeAAZ/jKv8FtYHybpchHgFAg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
+      "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.10.3"
+        "graphql-extensions": "^0.11.0"
       }
     },
     "apollo-datasource": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.3.tgz",
-      "integrity": "sha512-gRYyFVpJgHE2hhS+VxMeOerxXQ/QYxWG7T6QddfugJWYAG9DRCl65e2b7txcGq2NP3r+O1iCm4GNwhRBDJbd8A==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
+      "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
       "requires": {
-        "apollo-server-caching": "^0.5.0",
+        "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3"
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.6.tgz",
-      "integrity": "sha512-acfb7oFnru/8YQdY4x6+7WJbZfzdVETI8Cl+9ImgUrvUnE8P+f2SsGTKXTC1RuUvve4c56PAvaPgE+z8X1a1Mw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
+      "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.0",
-        "apollo-graphql": "^0.3.3",
-        "apollo-server-caching": "^0.5.0",
+        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-graphql": "^0.4.0",
+        "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.2.4",
+        "apollo-server-errors": "^2.4.0",
+        "apollo-server-types": "^0.3.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "^0.10.3"
+        "graphql-extensions": "^0.11.0"
       }
     },
     "apollo-engine-reporting-protobuf": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.0.tgz",
-      "integrity": "sha512-cXHZSienkis8v4RhqB3YG3DkaksqLpcxApRLTpRMs7IXNozgV7CUPYGFyFBEra1ZFgUyHXx4G9MpelV+n2cCfA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
+      "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
       "requires": {
-        "protobufjs": "^6.8.6"
+        "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-env": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
-      "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
+      "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
       "requires": {
+        "@types/node-fetch": "2.5.5",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.3.tgz",
-      "integrity": "sha512-t3CO/xIDVsCG2qOvx2MEbuu4b/6LzQjcBBwiVnxclmmFyAxYCIe7rpPlnLHSq7HyOMlCWDMozjoeWfdqYSaLqQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
+      "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
       "requires": {
-        "apollo-env": "0.5.1",
+        "apollo-env": "^0.6.2",
         "lodash.sortby": "^4.7.0"
       }
     },
@@ -626,33 +666,33 @@
       }
     },
     "apollo-server-caching": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.0.tgz",
-      "integrity": "sha512-l7ieNCGxUaUAVAAp600HjbUJxVaxjJygtPV0tPTe1Q3HkPy6LEWoY6mNHV7T268g1hxtPTxcdRu7WLsJrg7ufw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
+      "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
       "requires": {
         "lru-cache": "^5.0.0"
       }
     },
     "apollo-server-core": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.3.tgz",
-      "integrity": "sha512-KQpOM3nAXdMqKVE0HHcOkH/EVhyDqFEKLNFlsyGHGOn9ujpI6RsltX+YpXRyAdbfQHpTk11v/IAo6XksWN+g1Q==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
+      "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
       "requires": {
-        "@apollographql/apollo-tools": "^0.4.0",
+        "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/graphql-upload": "^8.0.0",
         "@types/ws": "^6.0.0",
-        "apollo-cache-control": "^0.8.4",
-        "apollo-datasource": "^0.6.3",
-        "apollo-engine-reporting": "^1.4.6",
-        "apollo-server-caching": "^0.5.0",
+        "apollo-cache-control": "^0.9.0",
+        "apollo-datasource": "^0.7.0",
+        "apollo-engine-reporting": "^1.7.0",
+        "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.3.3",
-        "apollo-server-plugin-base": "^0.6.4",
-        "apollo-server-types": "^0.2.4",
-        "apollo-tracing": "^0.8.4",
+        "apollo-server-errors": "^2.4.0",
+        "apollo-server-plugin-base": "^0.7.0",
+        "apollo-server-types": "^0.3.0",
+        "apollo-tracing": "^0.9.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.10.3",
+        "graphql-extensions": "^0.11.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
@@ -671,9 +711,9 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.3.tgz",
-      "integrity": "sha512-MO4oJ129vuCcbqwr5ZwgxqGGiLz3hCyowz0bstUF7MR+vNGe4oe3DWajC9lv4CxrhcqUHQOeOPViOdIo1IxE3g=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
+      "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
     },
     "apollo-server-express": {
       "version": "2.11.0",
@@ -867,30 +907,30 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.4.tgz",
-      "integrity": "sha512-4rY+cBAIpQomGWYBtk8hHkLQWHrh5hgIBPQqmhXh00YFdcY+Ob1/cU2/2iqTcIzhtcaezsc8OZ63au6ahSBQqg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
+      "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
       "requires": {
-        "apollo-server-types": "^0.2.4"
+        "apollo-server-types": "^0.3.0"
       }
     },
     "apollo-server-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.4.tgz",
-      "integrity": "sha512-G4FvBVgGQcTW6ZBS2+hvcDQkSfdOIKV+cHADduXA275v+5zl42g+bCaGd/hCCKTDRjmQvObLiMxH/BJ6pDMQgA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
+      "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.0",
-        "apollo-server-caching": "^0.5.0",
+        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3"
       }
     },
     "apollo-tracing": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.4.tgz",
-      "integrity": "sha512-DjbFW0IvHicSlTVG+vK+1WINfBMRCdPPHJSW/j65JMir9Oe56WGeqL8qz8hptdUUmLYEb+azvcyyGsJsiR3zpQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
+      "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.10.3"
+        "graphql-extensions": "^0.11.0"
       }
     },
     "apollo-utilities": {
@@ -903,6 +943,11 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
       }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -931,6 +976,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -968,6 +1018,15 @@
         }
       }
     },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "busboy": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
@@ -980,6 +1039,42 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "cacache": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-14.0.0.tgz",
+      "integrity": "sha512-+Nr/BnA/tjAUXza9gH8F+FSP+1HvWqCKt4c95dQr4EDVJVafbzmPZpLKCkLYexs6vSd2B/1TOXrAoNnqVPfvRA==",
+      "requires": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "tar": "^6.0.0",
+        "unique-filename": "^1.1.1"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -1001,6 +1096,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -1032,10 +1132,38 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
     "core-js": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
       "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
@@ -1100,6 +1228,20 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+    },
     "es-abstract": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
@@ -1121,6 +1263,19 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -1187,6 +1342,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "figgy-pudding": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1226,10 +1386,52 @@
       "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
       "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "graphql": {
       "version": "14.6.0",
@@ -1240,13 +1442,13 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.3.tgz",
-      "integrity": "sha512-kwU0gUe+Qdfr8iZYT91qrPSwQNgPhB/ClF1m1LEPdxlptk5FhFmjpxAcbMZ8q7j0kjfnbp2IeV1OhRDCEPqz2w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
+      "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
       "requires": {
-        "@apollographql/apollo-tools": "^0.4.0",
+        "@apollographql/apollo-tools": "^0.4.3",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.2.4"
+        "apollo-server-types": "^0.3.0"
       }
     },
     "graphql-relay": {
@@ -1306,6 +1508,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
     "http-errors": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -1318,6 +1525,62 @@
         "toidentifier": "1.0.0"
       }
     },
+    "http-proxy-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-uGuJaBWQWDQCJI5ip0d/VTYZW0nRrlLWXA4A7P1jrsa+f77rW2yXz315oBt6zGCF6l8C2tlMxY7ffULCj+5FhA==",
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1326,10 +1589,44 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -1345,6 +1642,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -1362,6 +1664,11 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "iterall": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
@@ -1378,9 +1685,9 @@
       "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
     },
     "loglevel": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
-      "integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g=="
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
     },
     "loglevel-debug": {
       "version": "0.0.1",
@@ -1401,6 +1708,28 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "make-fetch-happen": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-7.1.1.tgz",
+      "integrity": "sha512-7fNjiOXNZhNGQzG5P15nU97aZQtzPU2GVgVd7pnqnl5gnpLzMAD8bAe5YG4iW2s0PTqaZy9xGv4Wfqe872kRNQ==",
+      "requires": {
+        "agentkeepalive": "^4.1.0",
+        "cacache": "^14.0.0",
+        "http-cache-semantics": "^4.0.3",
+        "http-proxy-agent": "^3.0.0",
+        "https-proxy-agent": "^4.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.1.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^7.0.1"
       }
     },
     "media-typer": {
@@ -1434,6 +1763,122 @@
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
         "mime-db": "1.43.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-fetch": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.2.1.tgz",
+      "integrity": "sha512-ssHt0dkljEDaKmTgQ04DQgx2ag6G2gMPxA5hpcsoeTbfDgRf2fC2gNSRc6kISjD7ckCpHwwQvXxuTBK8402fXg==",
+      "requires": {
+        "encoding": "^0.1.12",
+        "minipass": "^3.1.0",
+        "minipass-pipeline": "^1.2.2",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "ms": {
@@ -1483,10 +1928,31 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -1509,24 +1975,30 @@
         "react-is": "^16.8.4"
       }
     },
-    "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+        }
       }
     },
     "proxy-addr": {
@@ -1579,14 +2051,51 @@
       }
     },
     "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "requires": {
+        "aproba": "^1.1.1"
+      }
     },
     "safe-buffer": {
       "version": "5.2.0",
@@ -1650,6 +2159,48 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+    },
+    "socks": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "requires": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        }
+      }
+    },
+    "ssri": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^3.1.1"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -1659,6 +2210,21 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "subscriptions-transport-ws": {
       "version": "0.9.16",
@@ -1687,6 +2253,26 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
+    "tar": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.1.tgz",
+      "integrity": "sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==",
+      "requires": {
+        "chownr": "^1.1.3",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.0",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -1714,10 +2300,31 @@
         "mime-types": "~2.1.24"
       }
     },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -1742,6 +2349,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "repository": "victorandree/apollo-federation-relay",
   "license": "MIT",
   "dependencies": {
-    "@apollo/federation": "^0.9.4",
+    "@apollo/federation": "^0.13.2",
     "@apollo/gateway": "^0.10.4",
-    "apollo-server": "^2.9.3",
-    "graphql": "^14.5.6",
+    "apollo-server": "^2.11.0",
+    "graphql": "^14.6.0",
     "graphql-relay": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@apollo/federation": "^0.13.2",
-    "@apollo/gateway": "^0.10.4",
+    "@apollo/gateway": "^0.13.2",
     "apollo-server": "^2.11.0",
     "graphql": "^14.6.0",
     "graphql-relay": "^0.6.0"


### PR DESCRIPTION
This PR bumps the dependencies to their latest versions, and makes small tweaks to `NodeGateway` to fix compatibility issues in newer versions of @apollo/gateway.