### PR TITLE
Support service-level node queries (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Support
 
-- [x] [Relay Global Object Identification]: Only at the gateway level (see TODO)
+- [x] [Relay Global Object Identification]
 - [x] [Relay Cursor Connections]
 
 [Relay Input Object Mutations] are no longer a required part of Relay,

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ query {
 
 - [x] Automatically generate schema for Node resolution service in gateway
 - [x] Run Node resolution service locally in gateway
-- [ ] Support `query { node }` in each service
+- [x] Support `query { node }` in each service
 
 [Relay Global Object Identification]: https://relay.dev/graphql/objectidentification.htm
 [Relay Cursor Connections]: https://relay.dev/graphql/connections.htm

--- a/node-gateway.js
+++ b/node-gateway.js
@@ -65,26 +65,25 @@ class NodeGateway extends ApolloGateway {
         ObjectTypeDefinition(node) {
           const name = node.name.value;
 
-          // Remove existing `query { node }` from service
+          // Remove existing `query { node }` from service to avoid collisions
           if (name === 'Query') {
             return visit(node, {
               FieldDefinition(node) {
-                const name = node.name.value;
-                if (name === 'node') {
+                if (node.name.value === 'node') {
                   return null;
                 }
               },
             });
           }
 
-          // Find the the types that implement the Node interface
-          if (!isNode(node) || seenNodeTypes.has(name)) {
-            return;
-          } else {
+          // Add any new Nodes from this service to the Node service's modules
+          if (isNode(node) && !seenNodeTypes.has(name)) {
             // We don't need any resolvers for these modules; they're just
             // simple objects with a single `id` property.
             modules.push({ typeDefs: toTypeDefs(name) });
             seenNodeTypes.add(name);
+
+            return;
           }
         },
       });

--- a/node-gateway.js
+++ b/node-gateway.js
@@ -63,6 +63,22 @@ class NodeGateway extends ApolloGateway {
     const modules = [];
     const seenNodeTypes = new Set();
     for (const service of defs.serviceDefinitions) {
+      // Remove existing `query { node }` from service
+      service.typeDefs = visit(service.typeDefs, {
+        ObjectTypeDefinition(node) {
+          const name = node.name.value;
+          if (name === "Query"){
+            return visit(node, {
+              FieldDefinition(node) {
+                const name = node.name.value
+                if (name === "node") {
+                  return null
+                }
+              }
+            })
+          }
+        }
+      })
       visit(service.typeDefs, {
         ObjectTypeDefinition(node) {
           const name = node.name.value;

--- a/node-gateway.js
+++ b/node-gateway.js
@@ -138,7 +138,7 @@ class NodeGateway extends ApolloGateway {
       // Cache the created DataSource
       this.serviceMap[serviceDef.name] = { dataSource };
 
-      return dataSource
+      return dataSource;
     }
 
     return super.createAndCacheDataSource(serviceDef);

--- a/node-gateway.js
+++ b/node-gateway.js
@@ -1,7 +1,4 @@
-const {
-  ApolloGateway,
-  LocalGraphQLDataSource,
-} = require('@apollo/gateway');
+const { ApolloGateway, LocalGraphQLDataSource } = require('@apollo/gateway');
 const { gql } = require('apollo-server');
 const { parse, visit, graphqlSync } = require('graphql');
 const { buildFederatedSchema } = require('@apollo/federation');
@@ -67,18 +64,18 @@ class NodeGateway extends ApolloGateway {
       service.typeDefs = visit(service.typeDefs, {
         ObjectTypeDefinition(node) {
           const name = node.name.value;
-          if (name === "Query"){
+          if (name === 'Query') {
             return visit(node, {
               FieldDefinition(node) {
-                const name = node.name.value
-                if (name === "node") {
-                  return null
+                const name = node.name.value;
+                if (name === 'node') {
+                  return null;
                 }
-              }
-            })
+              },
+            });
           }
-        }
-      })
+        },
+      });
       visit(service.typeDefs, {
         ObjectTypeDefinition(node) {
           const name = node.name.value;

--- a/server-product.js
+++ b/server-product.js
@@ -31,6 +31,7 @@ const PRODUCTS_MAP = toRecords(PRODUCTS);
 
 const typeDefs = gql`
   type Query {
+    node(id: ID!): Node
     product(id: ID!): Product
     products(ids: [ID!]): [Product]
   }
@@ -64,8 +65,19 @@ const typeDefs = gql`
   }
 `;
 
+const nodeTypes = new Set(['Product']);
+
 const resolvers = {
   Query: {
+    node(_, { id }) {
+      const [typename] = GraphQLNode.fromId(id);
+      if (!nodeTypes.has(typename)) {
+        throw new Error(`Invalid node ID "${id}"`);
+      }
+
+      return PRODUCTS_MAP[id];
+    },
+
     product(_, { id }) {
       return PRODUCTS_MAP[id];
     },

--- a/server-review.js
+++ b/server-review.js
@@ -35,6 +35,7 @@ const REVIEWS_MAP = toRecords(REVIEWS);
 
 const typeDefs = gql`
   type Query {
+    node(id: ID!): Node
     review(id: ID!): Review
     reviews(ids: [ID!]): [Review]
   }
@@ -74,8 +75,18 @@ const typeDefs = gql`
   }
 `;
 
+const nodeTypes = new Set(['Review']);
+
 const resolvers = {
   Query: {
+    node(_, { id }) {
+      const [typename] = GraphQLNode.fromId(id);
+      if (!nodeTypes.has(typename)) {
+        throw new Error(`Invalid node ID "${id}"`);
+      }
+
+      return REVIEWS_MAP[id];
+    },
     review(_, { id }) {
       return REVIEWS_MAP[id];
     },


### PR DESCRIPTION
Fixes #2 

My strategy here is to strip the `query { node }` fields from each service AST, so the federator doesn't know about them and won't complain about the duplicates!

The only thing left is to implement the node queries and their resolvers in each service schema. I work in Graphene (Python), so I'm not familiar with how you would do that correctly. Can you give me some guidance?