### PR TITLE
Add support for Apollo Gateway 0.15.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.vscode

--- a/node-gateway.js
+++ b/node-gateway.js
@@ -126,20 +126,14 @@ class NodeGateway extends ApolloGateway {
   }
 
   /**
-   * Override `createAndCacheDataSource` to support local Node resolution service.
+   * Override `createDataSource` to let the local Node resolution service be
+   * created without complaining about missing a URL.
    */
-  createAndCacheDataSource(serviceDef) {
-    // Special case for the local Node resolution service
+  createDataSource(serviceDef) {
     if (serviceDef.schema) {
-      const dataSource = new LocalGraphQLDataSource(serviceDef.schema);
-
-      // Cache the created DataSource
-      this.serviceMap[serviceDef.name] = { dataSource };
-
-      return dataSource;
+      return new LocalGraphQLDataSource(serviceDef.schema);
     }
-
-    return super.createAndCacheDataSource(serviceDef);
+    return super.createDataSource(serviceDef);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,62 +4,35 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@apollo/federation": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.13.2.tgz",
-      "integrity": "sha512-62uXIIHxHXG71gSwROFt8yxtYeUZ2BaIgAkxZ1H82GB4+s1gt4xwizcmmCWqQhK3KBy4LbPOfI1YyHW4Wv5ZpQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.15.0.tgz",
+      "integrity": "sha512-L6n41obKc0fLQdZ0uSHhHRJNCIAxZ5uDeqQON+Q+ewiUfS3XetCCf/cGpiiL50TIY/n8Bvh5ZPWLMTtP0tyw5g==",
       "requires": {
         "apollo-graphql": "^0.4.0",
         "apollo-server-env": "^2.4.3",
         "core-js": "^3.4.0",
         "lodash.xorby": "^4.7.0"
-      },
-      "dependencies": {
-        "apollo-env": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
-          "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
-          "requires": {
-            "@types/node-fetch": "2.5.5",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "apollo-graphql": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
-          "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
-          "requires": {
-            "apollo-env": "^0.6.2",
-            "lodash.sortby": "^4.7.0"
-          }
-        },
-        "core-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
-        }
       }
     },
     "@apollo/gateway": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.13.2.tgz",
-      "integrity": "sha512-1f5qCzplvE4sGFhK/ir2YUuFLTRO8ujEcSbsFFsHA+n4E8e8S92V+9X32MRXzu3gZYkfqdhnrd/bJFtTVtlkWA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.15.0.tgz",
+      "integrity": "sha512-p5BJfniAzbeJpkJxqFy1xmiSnNBOl5z0fiMuBIf9SXYO5WTRWuo2bzvB+Vme1rQ6gG/uws2DJxMguvBPsQ0Elw==",
       "requires": {
-        "@apollo/federation": "^0.13.2",
+        "@apollo/federation": "^0.15.0",
         "@types/node-fetch": "2.5.4",
-        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-engine-reporting-protobuf": "^0.5.0",
         "apollo-env": "^0.6.1",
         "apollo-graphql": "^0.4.0",
         "apollo-server-caching": "^0.5.1",
-        "apollo-server-core": "^2.11.0",
+        "apollo-server-core": "^2.13.0",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.3.0",
-        "graphql-extensions": "^0.11.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-types": "^0.4.0",
+        "graphql-extensions": "^0.12.0",
         "loglevel": "^1.6.1",
-        "loglevel-debug": "^0.0.1",
-        "make-fetch-happen": "^7.1.1",
-        "pretty-format": "^24.7.0"
+        "make-fetch-happen": "^8.0.0",
+        "pretty-format": "^25.0.0"
       },
       "dependencies": {
         "@types/node-fetch": {
@@ -90,14 +63,21 @@
         "@types/long": "^4.0.0",
         "@types/node": "^10.1.0",
         "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+        }
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
-      "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.7.tgz",
+      "integrity": "sha512-6QjZz6aLq6QXHgJ1AmSg4C4cBmhF5z3g7LPsk4g+zJoWKxiFuSIbrTe12ETtn6wgPq//e5p2agbXYydIjqs7gw==",
       "requires": {
-        "apollo-env": "^0.6.2"
+        "apollo-env": "^0.6.4"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -106,13 +86,14 @@
       "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
     },
     "@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
       }
     },
     "@protobufjs/aspromise": {
@@ -169,6 +150,11 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
     "@types/accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
@@ -178,26 +164,36 @@
       }
     },
     "@types/body-parser": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
-      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "@types/connect": {
-      "version": "3.4.32",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "requires": {
         "@types/node": "*"
       }
     },
+    "@types/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
+    },
     "@types/cookies": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.2.tgz",
-      "integrity": "sha512-jnihWgshWystcJKrz8C9hV+Ot9lqOUyAh2RF+o3BEo6K6AS2l4zYCb9GYaBuZ3C6Il59uIGqpE3HvCun4KKeJA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
+      "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -214,21 +210,23 @@
       }
     },
     "@types/express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
-      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.6.tgz",
+      "integrity": "sha512-U2oynuRIB17GIbEdvjFrrEACOy7GQkzsX7bPEBz1H41vZYEU4j0fLL97sawmHDwHUXpUQDBMHIyM9vejqP9o1A==",
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
     },
@@ -279,16 +277,17 @@
       }
     },
     "@types/keygrip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
-      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.49.tgz",
-      "integrity": "sha512-WQWpCH8O4Dslk8IcXfazff40aM1jXX7BQRbADIj/fKozVPu76P/wQE4sRe2SCWMn8yNkOcare2MkDrnZqLMkPQ==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.3.tgz",
+      "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
       "requires": {
         "@types/accepts": "*",
+        "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
         "@types/keygrip": "*",
@@ -297,17 +296,17 @@
       }
     },
     "@types/koa-compose": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.4.tgz",
-      "integrity": "sha512-ioou0rxkuWL+yBQYsHUQAzRTfVxAg8Y2VfMftU+Y3RA03/MzuFL0x/M2sXXj3PkfnENbHsjeHR1aMdezLYpTeA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
+      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
       "requires": {
         "@types/koa": "*"
       }
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -315,18 +314,23 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "10.14.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
-      "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
+      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
     },
     "@types/node-fetch": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
-      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.6.tgz",
+      "integrity": "sha512-2w0NTwMWF1d3NJMK0Uiq2UNN8htVCyOWOD0jIPjPgC5Ph/YP4dVhs9YxxcMcuLuwAslz0dVEcZQUaqkLs3IzOQ==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "@types/qs": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
+      "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -343,17 +347,17 @@
       }
     },
     "@types/ws": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
-      "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
+      "integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/yargs": {
-      "version": "13.0.8",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
-      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+      "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -364,9 +368,9 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -381,33 +385,21 @@
       }
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "agentkeepalive": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.0.tgz",
-      "integrity": "sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.2.tgz",
+      "integrity": "sha512-waNHE7tQBBn+2qXucI8HY0o2Y0OBPWldWOWsZwY71JcCm4SvrPnWdceFfB5NIXSqE8Ewq6VR/Qt5b1i69P6KCQ==",
       "requires": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
         "humanize-ms": "^1.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "aggregate-error": {
@@ -420,25 +412,26 @@
       }
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
       }
     },
     "apollo-cache-control": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
-      "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.10.0.tgz",
+      "integrity": "sha512-UIcPlrPdRTOKrF7kc5/WD5i6EVkGEEqgOK/fMj92fnnxR1KnQDiN82lqaxu02eZJvWjFJjik0JVJNXKOJXVrpQ==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.12.0"
       }
     },
     "apollo-datasource": {
@@ -451,218 +444,69 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
-      "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.8.0.tgz",
+      "integrity": "sha512-VPVpIGW6lbYXga6sqq/fG8ZaPR70bFuxvCov6X0npuVQPXwgZrzBp50cHx9uIaBVxDDxD3leeznsQbmF37RAww==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-engine-reporting-protobuf": "^0.5.0",
         "apollo-graphql": "^0.4.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
-        "apollo-server-types": "^0.3.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-types": "^0.4.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.12.0"
       }
     },
     "apollo-engine-reporting-protobuf": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
-      "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.0.tgz",
+      "integrity": "sha512-OgMwtLcuL+YAaO2xgkPbnRJnISLDSNE5F11p7oq+1ws+ws71CPfHAthDCxSObCPSALdhsLAGD0v3u3soBuNmMg==",
       "requires": {
         "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-env": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
-      "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.4.tgz",
+      "integrity": "sha512-8tGDMFv3sZLd76b/ZAo8GbdWU5Qt3VEUWSB+FLN41p/hVShZw0XIo2s/i8pVCTAhaWiEiD0Cr+d/zi0/h5UTxA==",
       "requires": {
-        "@types/node-fetch": "2.5.5",
+        "@types/node-fetch": "2.5.6",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
-      "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.3.tgz",
+      "integrity": "sha512-eAl8w6TeuY0Q3x7TVqBjt4JObA34vUyctuDn2lOmkdIqlu1EKxNAnTlRtXkjQM89qUt0rK0teU8No0a2lMNGuw==",
       "requires": {
-        "apollo-env": "^0.6.2",
+        "apollo-env": "^0.6.4",
         "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-link": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
-      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.20"
+        "zen-observable-ts": "^0.8.21"
       }
     },
     "apollo-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.11.0.tgz",
-      "integrity": "sha512-UhW6RHPBMWZy1v7KhzssUnxPBxpu9fGFajtqP68vtvvP3+xa2Y2GUg0594bHcUcLK+BjdMBQQSW27i0yQ/Fz9g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.13.0.tgz",
+      "integrity": "sha512-hbfxbgi6bpteBki2aKHRxS5FvsqpL7TLOrR99jWibCxVY2RYZZ0DtiT7RyFDZ0SLohdKzut2Rri67waRXBcDnA==",
       "requires": {
-        "apollo-server-core": "^2.11.0",
-        "apollo-server-express": "^2.11.0",
+        "apollo-server-core": "^2.13.0",
+        "apollo-server-express": "^2.13.0",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
-      },
-      "dependencies": {
-        "@apollographql/apollo-tools": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
-          "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
-          "requires": {
-            "apollo-env": "^0.6.2"
-          }
-        },
-        "apollo-cache-control": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
-          "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
-          "requires": {
-            "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.11.0"
-          }
-        },
-        "apollo-datasource": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
-          "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
-          "requires": {
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3"
-          }
-        },
-        "apollo-engine-reporting": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
-          "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.4",
-            "apollo-graphql": "^0.4.0",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3",
-            "apollo-server-errors": "^2.4.0",
-            "apollo-server-types": "^0.3.0",
-            "async-retry": "^1.2.1",
-            "graphql-extensions": "^0.11.0"
-          }
-        },
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
-          "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
-        "apollo-env": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
-          "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
-          "requires": {
-            "@types/node-fetch": "2.5.5",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "apollo-graphql": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
-          "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
-          "requires": {
-            "apollo-env": "^0.6.2",
-            "lodash.sortby": "^4.7.0"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
-          "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
-          "requires": {
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "apollo-server-core": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
-          "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "@apollographql/graphql-playground-html": "1.6.24",
-            "@types/graphql-upload": "^8.0.0",
-            "@types/ws": "^6.0.0",
-            "apollo-cache-control": "^0.9.0",
-            "apollo-datasource": "^0.7.0",
-            "apollo-engine-reporting": "^1.7.0",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3",
-            "apollo-server-errors": "^2.4.0",
-            "apollo-server-plugin-base": "^0.7.0",
-            "apollo-server-types": "^0.3.0",
-            "apollo-tracing": "^0.9.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.11.0",
-            "graphql-tag": "^2.9.2",
-            "graphql-tools": "^4.0.0",
-            "graphql-upload": "^8.0.2",
-            "sha.js": "^2.4.11",
-            "subscriptions-transport-ws": "^0.9.11",
-            "ws": "^6.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
-          "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
-          "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
-          "requires": {
-            "apollo-server-types": "^0.3.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
-          "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.4",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3"
-          }
-        },
-        "apollo-tracing": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
-          "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
-          "requires": {
-            "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.11.0"
-          }
-        },
-        "graphql-extensions": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
-          "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "apollo-server-env": "^2.4.3",
-            "apollo-server-types": "^0.3.0"
-          }
-        }
       }
     },
     "apollo-server-caching": {
@@ -674,28 +518,29 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
-      "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.13.0.tgz",
+      "integrity": "sha512-PqfsexbyObaQYb2jODs8v/XzrJcn+5mh0jA8ZfQCg5GENlua/CjeTZbRm2X0p3qpwc2E5jFAXSshrIWvhQAGZQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/graphql-upload": "^8.0.0",
-        "@types/ws": "^6.0.0",
-        "apollo-cache-control": "^0.9.0",
+        "@types/ws": "^7.0.0",
+        "apollo-cache-control": "^0.10.0",
         "apollo-datasource": "^0.7.0",
-        "apollo-engine-reporting": "^1.7.0",
+        "apollo-engine-reporting": "^1.8.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
-        "apollo-server-plugin-base": "^0.7.0",
-        "apollo-server-types": "^0.3.0",
-        "apollo-tracing": "^0.9.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.8.0",
+        "apollo-server-types": "^0.4.0",
+        "apollo-tracing": "^0.10.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.11.0",
+        "graphql-extensions": "^0.12.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
+        "loglevel": "^1.6.7",
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "ws": "^6.0.0"
@@ -711,23 +556,23 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
-      "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
+      "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
     },
     "apollo-server-express": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.11.0.tgz",
-      "integrity": "sha512-9bbiD+zFAx+xyurc9lxYmNa9y79k/gsA1vEyPFVcv7jxzCFC5wc0tcbV7NPX2qi1Nn7K76fxo2fPNYbPFX/y0g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.13.0.tgz",
+      "integrity": "sha512-xDc+kRqWCXs4MeRjls37G45V6PmKYwo7OlpWCXyWDSPGgY9UD4E5A6rUBCyIhoNr7RnVYMkNuySOOqzX1QJ7EA==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
         "@types/cors": "^2.8.4",
-        "@types/express": "4.17.2",
+        "@types/express": "4.17.4",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.11.0",
-        "apollo-server-types": "^0.3.0",
+        "apollo-server-core": "^2.13.0",
+        "apollo-server-types": "^0.4.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
@@ -738,216 +583,56 @@
         "type-is": "^1.6.16"
       },
       "dependencies": {
-        "@apollographql/apollo-tools": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
-          "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
-          "requires": {
-            "apollo-env": "^0.6.2"
-          }
-        },
-        "@types/body-parser": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-          "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-          "requires": {
-            "@types/connect": "*",
-            "@types/node": "*"
-          }
-        },
         "@types/express": {
-          "version": "4.17.2",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-          "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.4.tgz",
+          "integrity": "sha512-DO1L53rGqIDUEvOjJKmbMEQ5Z+BM2cIEPy/eV3En+s166Gz+FeuzRerxcab757u/U4v4XF4RYrZPmqKa+aY/2w==",
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "*",
+            "@types/qs": "*",
             "@types/serve-static": "*"
-          }
-        },
-        "apollo-cache-control": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
-          "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
-          "requires": {
-            "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.11.0"
-          }
-        },
-        "apollo-datasource": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
-          "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
-          "requires": {
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3"
-          }
-        },
-        "apollo-engine-reporting": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
-          "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.4",
-            "apollo-graphql": "^0.4.0",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3",
-            "apollo-server-errors": "^2.4.0",
-            "apollo-server-types": "^0.3.0",
-            "async-retry": "^1.2.1",
-            "graphql-extensions": "^0.11.0"
-          }
-        },
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
-          "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
-        "apollo-env": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
-          "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
-          "requires": {
-            "@types/node-fetch": "2.5.5",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "apollo-graphql": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
-          "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
-          "requires": {
-            "apollo-env": "^0.6.2",
-            "lodash.sortby": "^4.7.0"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.1.tgz",
-          "integrity": "sha512-L7LHZ3k9Ao5OSf2WStvQhxdsNVplRQi7kCAPfqf9Z3GBEnQ2uaL0EgO0hSmtVHfXTbk5CTRziMT1Pe87bXrFIw==",
-          "requires": {
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "apollo-server-core": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
-          "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "@apollographql/graphql-playground-html": "1.6.24",
-            "@types/graphql-upload": "^8.0.0",
-            "@types/ws": "^6.0.0",
-            "apollo-cache-control": "^0.9.0",
-            "apollo-datasource": "^0.7.0",
-            "apollo-engine-reporting": "^1.7.0",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3",
-            "apollo-server-errors": "^2.4.0",
-            "apollo-server-plugin-base": "^0.7.0",
-            "apollo-server-types": "^0.3.0",
-            "apollo-tracing": "^0.9.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.11.0",
-            "graphql-tag": "^2.9.2",
-            "graphql-tools": "^4.0.0",
-            "graphql-upload": "^8.0.2",
-            "sha.js": "^2.4.11",
-            "subscriptions-transport-ws": "^0.9.11",
-            "ws": "^6.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
-          "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
-        },
-        "apollo-server-plugin-base": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
-          "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
-          "requires": {
-            "apollo-server-types": "^0.3.0"
-          }
-        },
-        "apollo-server-types": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
-          "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.4.4",
-            "apollo-server-caching": "^0.5.1",
-            "apollo-server-env": "^2.4.3"
-          }
-        },
-        "apollo-tracing": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
-          "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
-          "requires": {
-            "apollo-server-env": "^2.4.3",
-            "graphql-extensions": "^0.11.0"
-          }
-        },
-        "graphql-extensions": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
-          "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "apollo-server-env": "^2.4.3",
-            "apollo-server-types": "^0.3.0"
           }
         }
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
-      "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.8.0.tgz",
+      "integrity": "sha512-H8sJlOVJrF0IhYIFMv7NOgB6BFgqobXSZrj1y9ju6dq13OotsqcZC4fJOYc9oWzb/+/mqg/odtVioE71mj68yg==",
       "requires": {
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.4.0"
       }
     },
     "apollo-server-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
-      "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.4.0.tgz",
+      "integrity": "sha512-U+6qKCdrucVSMEVvLSqSwxIGr3VI6vcfbhpD86sdb8MgHHGH6egjNAcLrPVRk1AyXs8RV0Ysus+vlj8rpouBzA==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-engine-reporting-protobuf": "^0.5.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3"
       }
     },
     "apollo-tracing": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
-      "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.10.0.tgz",
+      "integrity": "sha512-yuqA1KT0FQUfzVK3ZIk0hRIE8eUKx9Oklq83AGQxLtS/oafBj/VOCZAtJNJkyEqMJxXQT9uIBtbfO1789Gczkw==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.12.0"
       }
     },
     "apollo-utilities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
-      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
+      "integrity": "sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==",
       "requires": {
         "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
         "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
+        "tslib": "^1.10.0"
       }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -960,9 +645,9 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-retry": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
-      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
       "requires": {
         "retry": "0.12.0"
       }
@@ -999,6 +684,14 @@
         "type-is": "~1.6.17"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "http-errors": {
           "version": "1.7.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -1015,6 +708,11 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1041,35 +739,42 @@
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cacache": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-14.0.0.tgz",
-      "integrity": "sha512-+Nr/BnA/tjAUXza9gH8F+FSP+1HvWqCKt4c95dQr4EDVJVafbzmPZpLKCkLYexs6vSd2B/1TOXrAoNnqVPfvRA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.3.tgz",
+      "integrity": "sha512-bc3jKYjqv7k4pWh7I/ixIjfcjPul4V4jme/WbjvwGS5LzoPL/GzXr4C5EgPNLO/QEZl9Oi61iGitYEdwcrwLCQ==",
       "requires": {
-        "chownr": "^1.1.2",
-        "figgy-pudding": "^3.5.1",
+        "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
         "infer-owner": "^1.0.4",
         "lru-cache": "^5.1.1",
-        "minipass": "^3.0.0",
+        "minipass": "^3.1.1",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.2",
         "mkdirp": "^1.0.3",
-        "move-concurrently": "^1.0.1",
-        "p-map": "^3.0.0",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.7.1",
-        "ssri": "^7.0.0",
-        "tar": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
         "unique-filename": "^1.1.1"
       }
     },
+    "chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
     "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -1077,17 +782,17 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1132,38 +837,10 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "copy-concurrently": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-      "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
-      }
-    },
     "core-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "cors": {
       "version": "2.8.5",
@@ -1175,11 +852,11 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "define-properties": {
@@ -1243,39 +920,31 @@
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -1330,6 +999,19 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1338,14 +1020,9 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "figgy-pudding": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -1359,6 +1036,21 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "form-data": {
@@ -1394,17 +1086,6 @@
         "minipass": "^3.0.0"
       }
     },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1428,11 +1109,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-    },
     "graphql": {
       "version": "14.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
@@ -1442,13 +1118,13 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
-      "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.0.tgz",
+      "integrity": "sha512-kBRLtNeknrFl0W/UQQYebj6qnvb1E1RpQ2+C7Y8pwMc6yV8+9pWFx5RP0HzfeEuScCmK93i3H5sdPedoQWwENw==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.4.0"
       }
     },
     "graphql-relay": {
@@ -1468,16 +1144,16 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
-      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
+      "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
     },
     "graphql-tools": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
-      "integrity": "sha512-kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
+      "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
       "requires": {
-        "apollo-link": "^1.2.3",
+        "apollo-link": "^1.2.14",
         "apollo-utilities": "^1.0.1",
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
@@ -1485,13 +1161,13 @@
       }
     },
     "graphql-upload": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.7.tgz",
-      "integrity": "sha512-gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+      "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^2.0.4",
-        "http-errors": "^1.7.2",
+        "http-errors": "^1.7.3",
         "object-path": "^0.11.4"
       }
     },
@@ -1503,10 +1179,15 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -1526,51 +1207,22 @@
       }
     },
     "http-proxy-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-3.0.0.tgz",
-      "integrity": "sha512-uGuJaBWQWDQCJI5ip0d/VTYZW0nRrlLWXA4A7P1jrsa+f77rW2yXz315oBt6zGCF6l8C2tlMxY7ffULCj+5FhA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
       "requires": {
-        "agent-base": "5",
+        "@tootallnate/once": "1",
+        "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "humanize-ms": {
@@ -1588,11 +1240,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1634,14 +1281,14 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-lambda": {
       "version": "1.0.1",
@@ -1649,25 +1296,20 @@
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "iterall": {
       "version": "1.2.2",
@@ -1685,17 +1327,9 @@
       "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
     },
     "loglevel": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
-      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
-    },
-    "loglevel-debug": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/loglevel-debug/-/loglevel-debug-0.0.1.tgz",
-      "integrity": "sha1-ifidPboTy6iiy0YV1dOtcYn0iik=",
-      "requires": {
-        "loglevel": "^1.4.0"
-      }
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
     },
     "long": {
       "version": "4.0.0",
@@ -1711,15 +1345,15 @@
       }
     },
     "make-fetch-happen": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-7.1.1.tgz",
-      "integrity": "sha512-7fNjiOXNZhNGQzG5P15nU97aZQtzPU2GVgVd7pnqnl5gnpLzMAD8bAe5YG4iW2s0PTqaZy9xGv4Wfqe872kRNQ==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.6.tgz",
+      "integrity": "sha512-QJ4pB5VBY9H9e+3t/o+fPjsVUlPULpAllxuKertRo/7ii47TfxeEEnneM6NCmhyn4MQPTYL+M+RkiU9bR+hAfg==",
       "requires": {
         "agentkeepalive": "^4.1.0",
-        "cacache": "^14.0.0",
-        "http-cache-semantics": "^4.0.3",
-        "http-proxy-agent": "^3.0.0",
-        "https-proxy-agent": "^4.0.0",
+        "cacache": "^15.0.0",
+        "http-cache-semantics": "^4.0.4",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
         "lru-cache": "^5.1.1",
         "minipass": "^3.0.0",
@@ -1728,8 +1362,8 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.2",
         "promise-retry": "^1.1.1",
-        "socks-proxy-agent": "^4.0.0",
-        "ssri": "^7.0.1"
+        "socks-proxy-agent": "^5.0.0",
+        "ssri": "^8.0.0"
       }
     },
     "media-typer": {
@@ -1753,16 +1387,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "minimatch": {
@@ -1772,11 +1406,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",
@@ -1854,37 +1483,22 @@
       }
     },
     "mkdirp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
-    "move-concurrently": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+    "move-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/move-file/-/move-file-2.0.0.tgz",
+      "integrity": "sha512-cdkdhNCgbP5dvS4tlGxZbD+nloio9GIimP57EjqFhwLcMjnU+XJKAZzlmg/TN/AK1LuNAdTSvm3CPPP4Xkv0iQ==",
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
+        "path-exists": "^4.0.0"
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -1901,6 +1515,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1911,13 +1530,24 @@
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
       "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "on-finished": {
@@ -1937,9 +1567,9 @@
       }
     },
     "p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -1948,6 +1578,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1965,20 +1600,15 @@
       "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
     },
     "pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
       "requires": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
+        "@jest/types": "^25.5.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
       }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -2055,46 +1685,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "run-queue": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "requires": {
-        "aproba": "^1.1.1"
       }
     },
     "safe-buffer": {
@@ -2127,6 +1728,21 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -2174,30 +1790,20 @@
       }
     },
     "socks-proxy-agent": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
       "requires": {
-        "agent-base": "~4.2.1",
-        "socks": "~2.3.2"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        }
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
       }
     },
     "ssri": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-      "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+      "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
       "requires": {
-        "figgy-pudding": "^3.5.1",
         "minipass": "^3.1.1"
       }
     },
@@ -2211,19 +1817,42 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "subscriptions-transport-ws": {
@@ -2248,17 +1877,25 @@
         }
       }
     },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "tar": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.1.tgz",
-      "integrity": "sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
+      "integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
       "requires": {
-        "chownr": "^1.1.3",
+        "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
         "minizlib": "^2.1.0",
@@ -2287,9 +1924,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -2321,18 +1958,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
       }
     },
     "utils-merge": {
@@ -2341,9 +1975,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "vary": {
       "version": "1.1.2",
@@ -2364,19 +1998,19 @@
       }
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "zen-observable": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
-      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
-      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "repository": "victorandree/apollo-federation-relay",
   "license": "MIT",
   "dependencies": {
-    "@apollo/federation": "^0.13.2",
-    "@apollo/gateway": "^0.13.2",
-    "apollo-server": "^2.11.0",
+    "@apollo/federation": "^0.15.0",
+    "@apollo/gateway": "^0.15.0",
+    "apollo-server": "^2.13.0",
     "graphql": "^14.6.0",
     "graphql-relay": "^0.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@apollo/federation": "^0.15.0",
     "@apollo/gateway": "^0.15.0",
     "apollo-server": "^2.13.0",
-    "graphql": "^14.6.0",
     "graphql-relay": "^0.6.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@
  * Gateway server and main entrypoint
  */
 
- const { NodeGateway} = require('./node-gateway')
+const { NodeGateway } = require('./node-gateway');
 const { ApolloServer } = require('apollo-server');
 const { server: serverProduct } = require('./server-product');
 const { server: serverReview } = require('./server-review');

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ async function startServers() {
 
 async function main() {
   const serviceList = await startServers();
-  const gateway = new NodeGateway({ serviceList });
+  const gateway = new NodeGateway({ serviceList, serviceHealthCheck: true });
   const server = new ApolloServer({ gateway, subscriptions: false });
   const info = await server.listen(BASE_PORT);
 


### PR DESCRIPTION
This PR makes a couple of changes:

- Bump Apollo dependencies to their latest versions.
- Remove unused `graphql` dependency.
- Replace the `createAndCacheDataSource` override with `createDataSource` to handle instances when the NODE_SERVICE needs to meet Apollo's expectations. This was done specifically to support the [new `serviceHealthCheck` property](https://github.com/apollographql/apollo-server/pull/3930) of `ApolloGateway` config.
- Add Visual Studio Code's workspace settings directory to `.gitignore`.